### PR TITLE
Update to released version 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,5 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0
 
-# Pin pre-release PSResourceGet for fixes:
-# - PowerShell/PSResourceGet#1868: Repository store init
-# - PowerShell/PSResourceGet#1925: -WhatIf:$false passthrough
-ARG PSRESOURCEGET_VERSION=1.2.0-rc3
-RUN pwsh -c "Install-PSResource -Name Microsoft.PowerShell.PSResourceGet \
-            -Version $PSRESOURCEGET_VERSION -Prerelease -Scope AllUsers -TrustRepository" &&\
-    pwsh -c "Import-Module Microsoft.PowerShell.PSResourceGet \
-            -MinimumVersion ('$PSRESOURCEGET_VERSION' -replace '-.*') -ErrorAction Stop"
-
 COPY 'entrypoint.ps1' '/'
 
 ENTRYPOINT [ "/entrypoint.ps1" ]


### PR DESCRIPTION
Remove `PSResourceGet` pre-release pin

The `Dockerfile` was pinning to `PSResourceGet 1.2.0-rc3` to work around known bugs

`PSResourceGet 1.2.0` (stable) is now released with both fixes. This removes the pre-release pin and manual install entirely.

# Blocked ⚠️ 
Awaiting https://github.com/dotnet/dotnet-docker/pull/7108